### PR TITLE
Turn off 97% clustering by default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,7 @@ date: "29.11.2022"
 
 # UNITE Precluster percentage
 cluster:
-  - "97"
+#  - "97" # If you need these, please let me know: https://github.com/colinbrislawn/unite-train/issues 
   - "99"
   - "dynamic"
 


### PR DESCRIPTION
See discussion here: https://forum.qiime2.org/t/unite-classifiers/21895/2
>I am not sure that we will want pre-trained classifiers for everything, as it is a lot to maintain and some versions (e.g., 97% OTUs) are clearly not needed.

